### PR TITLE
Remove redundant curly bracket.

### DIFF
--- a/qml/EditorWindow.qml
+++ b/qml/EditorWindow.qml
@@ -76,7 +76,6 @@ Window {
                         app.mode = (app.mode == "code") ? "" : "code"
                         break
                     }
-                }
             }
 
             onSelectionStartChanged: scrollToSelection()


### PR DESCRIPTION
The brackets are not paired properly, which makes it fail to compile.
